### PR TITLE
fix(tests): remove unnecessary nolint comments in cleanup functions

### DIFF
--- a/examples/simple/collections_test.go
+++ b/examples/simple/collections_test.go
@@ -68,7 +68,7 @@ func TestCollectionsWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cl)
 		t.Cleanup(func() {
-			require.NoError(t, cl.Disconnect(context.Background())) //nolint:usetesting
+			require.NoError(t, cl.Disconnect(context.Background()))
 		})
 
 		db := cl.Database(fmt.Sprintf("simple_%d", time.Now().Unix()))

--- a/examples/simple/users_test.go
+++ b/examples/simple/users_test.go
@@ -111,7 +111,7 @@ func TestUsersWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cl)
 		t.Cleanup(func() {
-			require.NoError(t, cl.Disconnect(context.Background())) //nolint:usetesting
+			require.NoError(t, cl.Disconnect(context.Background()))
 		})
 
 		db := cl.Database(fmt.Sprintf("simple_%d", time.Now().Unix()))


### PR DESCRIPTION
Remove redundant nolint:usetesting comments from Disconnect calls in
users_test.go and collections_test.go cleanup functions to improve code
clarity and maintainability. The calls are properly handled by require.NoError.