### PR TITLE
fix(test): silence linter about missing context in exec.Command

### DIFF
--- a/examples/simple/main_test.go
+++ b/examples/simple/main_test.go
@@ -20,7 +20,7 @@ const (
 
 func TestMain(m *testing.M) {
 	fmt.Println("Building docker image...")
-	cmd := exec.Command(
+	cmd := exec.Command( //nolint:noctx
 		"docker",
 		"build", ".",
 		"--rm",
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	}
 
 	fmt.Println("Starting docker container...")
-	cmd = exec.Command(
+	cmd = exec.Command( //nolint:noctx
 		"docker",
 		"run",
 		"-d",
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 	}
 	defer func() {
 		fmt.Println("Stopping docker container...")
-		cmd := exec.Command(
+		cmd := exec.Command( //nolint:noctx
 			"docker",
 			"rm",
 			"--force",
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 	time.Sleep(10 * time.Second)
 
 	fmt.Println("Initializing mongodb...")
-	cmd = exec.Command(
+	cmd = exec.Command( //nolint:noctx
 		"docker",
 		"exec", DockerName,
 		"/usr/bin/mongosh",

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ const (
 
 func TestMain(m *testing.M) {
 	fmt.Println("Building docker image...")
-	cmd := exec.Command(
+	cmd := exec.Command( //nolint:noctx
 		"docker",
 		"build", ".",
 		"--rm",
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	}
 
 	fmt.Println("Starting docker container...")
-	cmd = exec.Command(
+	cmd = exec.Command( //nolint:noctx
 		"docker",
 		"run",
 		"-d",
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 	}
 	defer func() {
 		fmt.Println("Stopping docker container...")
-		cmd := exec.Command(
+		cmd := exec.Command( //nolint:noctx
 			"docker",
 			"rm",
 			"--force",
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 	time.Sleep(10 * time.Second)
 
 	fmt.Println("Initializing mongodb...")
-	cmd = exec.Command(
+	cmd = exec.Command( //nolint:noctx
 		"docker",
 		"exec", DockerName,
 		"/usr/bin/mongosh",


### PR DESCRIPTION
Add //nolint:noctx comments to exec.Command calls in main_test.go.
This suppresses linter warnings about using context-aware functions (e.g.
exec.CommandContext) in test setup/teardown where adding contexts would add
noise and not improve test behavior. The change keeps behavior identical
while making linters pass and keeping the test code concise.