### PR TITLE
chore(go): relax Go toolchain version in.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sv-tools/mongoifc/v2
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Update go.mod to use a generic Go .24 directive instead of the
explicit 1.24.0 patch version. This avoids unnecessary future edits
when applying minor toolchain updates and keeps the module compatible
with any Go 1.24.x release.